### PR TITLE
setup: extend use of cmake

### DIFF
--- a/setup/build_lin/build.sh
+++ b/setup/build_lin/build.sh
@@ -129,15 +129,12 @@ if [ $build_takin -ne 0 ]; then
 	pushd "${TAKIN_ROOT}/core"
 		../setup/build_general/clean.sh
 
-		mkdir -p build
-		cd build
-
-		if ! cmake -DDEBUG=False ..; then
+		if ! cmake -DDEBUG=False -B build . ; then
 			echo -e "Failed configuring core package."
 			exit -1
 		fi
 
-		if ! make -j${NUM_CORES}; then
+		if ! cmake --build build --parallel ${NUM_CORES} ; then
 			echo -e "Failed building core package."
 			exit -1
 		fi
@@ -152,15 +149,13 @@ if [ $build_takin2 -ne 0 ]; then
 
 	pushd "${TAKIN_ROOT}/mag-core"
 		rm -rf build
-		mkdir -p build
-		cd build
 
-		if ! cmake -DCMAKE_BUILD_TYPE=Release -DONLY_BUILD_FINISHED=True ..; then
+		if ! cmake -DCMAKE_BUILD_TYPE=Release -DONLY_BUILD_FINISHED=True -B build . ; then
 			echo -e "Failed configuring mag-core package."
 			exit -1
 		fi
 
-		if ! make -j${NUM_CORES}; then
+		if ! cmake --build build --parallel ${NUM_CORES} ; then
 			echo -e "Failed building mag-core package."
 			exit -1
 		fi
@@ -187,15 +182,13 @@ if [ $build_plugins -ne 0 ]; then
 
 	pushd "${TAKIN_ROOT}/magnon-plugin"
 		rm -rf build
-		mkdir -p build
-		cd build
 
-		if ! cmake -DCMAKE_BUILD_TYPE=Release ..; then
+		if ! cmake -DCMAKE_BUILD_TYPE=Release -B build . ; then
 			echo -e "Failed configuring magnon plugin."
 			exit -1
 		fi
 
-		if ! make -j${NUM_CORES}; then
+		if ! cmake --build build --parallel ${NUM_CORES} ; then
 			echo -e "Failed building magnon plugin."
 			exit -1
 		fi
@@ -213,15 +206,13 @@ if [ $build_py_modules -ne 0 ]; then
 
 	pushd "${TAKIN_ROOT}/mag-core/tools_py/magdyn"
 		rm -rf build
-		mkdir -p build
-		cd build
 
-		if ! cmake -DCMAKE_BUILD_TYPE=Release ..; then
+		if ! cmake -DCMAKE_BUILD_TYPE=Release -B build . ; then
 			echo -e "Failed configuring magnetic dynamics py module."
 			exit -1
 		fi
 
-		if ! make -j${NUM_CORES}; then
+		if ! cmake --build --parallel ${NUM_CORES} ; then
 			echo -e "Failed building magnetic dynamics py module."
 			exit -1
 		fi
@@ -232,15 +223,13 @@ if [ $build_py_modules -ne 0 ]; then
 
 	pushd "${TAKIN_ROOT}/mag-core/tools_py/instr"
 		rm -rf build
-		mkdir -p build
-		cd build
 
-		if ! cmake -DCMAKE_BUILD_TYPE=Release ..; then
+		if ! cmake -DCMAKE_BUILD_TYPE=Release -B build . ; then
 			echo -e "Failed configuring instrument data loader py module."
 			exit -1
 		fi
 
-		if ! make -j${NUM_CORES}; then
+		if ! cmake --build build --parallel ${NUM_CORES}; then
 			echo -e "Failed building instrument data loader py module."
 			exit -1
 		fi

--- a/setup/externals/build_lapacke.sh
+++ b/setup/externals/build_lapacke.sh
@@ -52,14 +52,14 @@ fi
 
 rm -rf build_lapacke
 unzip "${LAPACK_LOCAL}"
-mkdir build_lapacke
-cd build_lapacke
 
 
 if [ $BUILD_FOR_MINGW -ne 0 ]; then
+	mkdir build_lapacke
+	cd build_lapacke
 	mingw64-cmake -DCMAKE_BUILD_TYPE=Release -DLAPACKE=TRUE ../lapack-master
 	mingw64-make -j${NUM_CORES} && sudo mingw64-make install/strip
 else
-	cmake -DCMAKE_BUILD_TYPE=Release -DLAPACKE=TRUE -DBUILD_SHARED_LIBS=TRUE ../lapack-master
-	make -j${NUM_CORES} && sudo make install/strip
+	cmake -DCMAKE_BUILD_TYPE=Release -DLAPACKE=TRUE -DBUILD_SHARED_LIBS=TRUE -B build_lapacke lapack-master
+	cmake --build build_lapacke --parallel ${NUM_CORES} && sudo cmake --install --strip build_lapacke
 fi

--- a/setup/externals/build_minuit.sh
+++ b/setup/externals/build_minuit.sh
@@ -56,15 +56,13 @@ fi
 rm -rf ${MINUIT_DIR}
 unzip "${MINUIT_LOCAL}"
 cd ${MINUIT_DIR}/math/minuit2/
-mkdir build && cd build
 
 
 if [ $BUILD_FOR_MINGW -ne 0 ]; then
-	#mingw64-configure --disable-openmp
+	mkdir build && cd build
 	mingw64-cmake -DCMAKE_BUILD_TYPE=Release ..
 	mingw64-make -j${NUM_CORES} && sudo mingw64-make install/strip
 else
-	#./configure --disable-openmp
-	cmake -DCMAKE_BUILD_TYPE=Release ..
-	make -j${NUM_CORES} && sudo make install/strip
+	cmake -DCMAKE_BUILD_TYPE=Release -B build .
+	cmake -build build --parallel ${NUM_CORES} && sudo cmake --install --strip build
 fi

--- a/setup/externals/build_qhull.sh
+++ b/setup/externals/build_qhull.sh
@@ -53,15 +53,15 @@ fi
 rm -rf qhull-master
 unzip "${QHULL_LOCAL}"
 cd qhull-master
-mkdir build_lib && cd build_lib
 
 
 if [ $BUILD_FOR_MINGW -ne 0 ]; then
+	mkdir build_lib && cd build_lib
 	mingw64-cmake -DCMAKE_BUILD_TYPE=Release \
 		-DQHULL_ENABLE_TESTING=False -DBUILD_APPLICATIONS=False ..
 	mingw64-make -j${NUM_CORES} && sudo mingw64-make install/strip
 else
 	cmake -DCMAKE_BUILD_TYPE=Release \
-		-DQHULL_ENABLE_TESTING=False -DBUILD_APPLICATIONS=False ..
-	make -j${NUM_CORES} && sudo make install/strip
+		-DQHULL_ENABLE_TESTING=False -DBUILD_APPLICATIONS=False  -B build_lib .
+	cmake --build build_lib --parallel ${NUM_CORES} && sudo cmake --install --strip build_lib
 fi


### PR DESCRIPTION
The cmake program allows not only the configuration but the compiling and installing as well. This become quite helpful if there is no 'make' program for these jobs available or used.