### PR TITLE
Build: Fix typo in option

### DIFF
--- a/setup/build_lin/build.sh
+++ b/setup/build_lin/build.sh
@@ -220,7 +220,7 @@ if [ $build_plugins -ne 0 ]; then
 	pushd "${TAKIN_ROOT}/magnon-plugin"
 		rm -rf ${BUILD_DIR}
 
-		if ! cmake --DCMAKE_BUILD_TYPE=Release -B ${BUILD_DIR} . ; then
+		if ! cmake -DCMAKE_BUILD_TYPE=Release -B ${BUILD_DIR} . ; then
 			echo -e "Failed configuring magnon plugin."
 			exit -1
 		fi


### PR DESCRIPTION
Double '-' isn't allowed for the single character option 'D'