### PR TITLE
DEMOS: Add package for import of 'magdyn' py module

### DIFF
--- a/data/demos/magnon_Cu2OSeO3/calc_dispersion.py
+++ b/data/demos/magnon_Cu2OSeO3/calc_dispersion.py
@@ -26,7 +26,7 @@
 import time
 import numpy
 import numpy.linalg
-import magdyn
+from takin import magdyn
 
 
 # -----------------------------------------------------------------------------

--- a/data/demos/magnon_Cu2OSeO3/calc_dispersion_pointwise.py
+++ b/data/demos/magnon_Cu2OSeO3/calc_dispersion_pointwise.py
@@ -27,7 +27,7 @@
 import os
 import time
 import numpy
-import magdyn
+from takin import magdyn
 
 
 # -----------------------------------------------------------------------------

--- a/data/demos/magnon_Cu2OSeO3/create_model.py
+++ b/data/demos/magnon_Cu2OSeO3/create_model.py
@@ -24,7 +24,7 @@
 #
 
 import numpy
-import magdyn
+from takin import magdyn
 
 
 # -----------------------------------------------------------------------------

--- a/data/demos/magnon_Cu2OSeO3/create_model_pointwise.py
+++ b/data/demos/magnon_Cu2OSeO3/create_model_pointwise.py
@@ -25,7 +25,7 @@
 #
 
 import numpy
-import magdyn
+from takin import magdyn
 
 
 # -----------------------------------------------------------------------------

--- a/data/demos/magnon_Cu2OSeO3/load_model.py
+++ b/data/demos/magnon_Cu2OSeO3/load_model.py
@@ -25,7 +25,7 @@
 #
 
 import numpy
-import magdyn
+from takin import magdyn
 
 
 # -----------------------------------------------------------------------------

--- a/data/demos/magnon_Cu2OSeO3/load_model_pointwise.py
+++ b/data/demos/magnon_Cu2OSeO3/load_model_pointwise.py
@@ -25,7 +25,7 @@
 #
 
 import numpy
-import magdyn
+from takin import magdyn
 
 
 # -----------------------------------------------------------------------------

--- a/data/demos/magnon_afm/calc.py
+++ b/data/demos/magnon_afm/calc.py
@@ -24,7 +24,7 @@
 #
 
 import numpy
-import magdyn
+from takin import magdyn
 
 
 # options


### PR DESCRIPTION
Since the python components have been moved to the 'takin' package the import of the 'magdyn' has to be made via the 'takin' package now.