### PR TITLE
Missing list of dependencies in debian package noble v2.9

### DIFF
--- a/setup/build_lin/mkdeb_noble.sh
+++ b/setup/build_lin/mkdeb_noble.sh
@@ -74,7 +74,7 @@ echo -e "Depends:" \
 	"gnuplot," \
 	"gnuplot-qt," \
 	"libopengl0," \
-	"libgfortran5,"
+	"libgfortran5," \
 	"liblapacke," \
 	"libqhull-r8.0," \
 	"libqhullcpp8.0," \


### PR DESCRIPTION
This fixes missing dependencies list in debian package
in particular the system complaint for missing libqt6svg
Cause missing backslash in shell script
